### PR TITLE
need argv set to work properly for argparse

### DIFF
--- a/main.c
+++ b/main.c
@@ -149,7 +149,9 @@ static PyMethodDef pppd_stdout_methods[] = {
  */
 int pyinit() {
     char *err;
+    char *argv[] = { "pppd_pyhook", NULL };
     Py_Initialize();
+    PySys_SetArgvEx(0, argv, 0);
 
     // Redirect stdout/stderr - this will also give us our
     // python error debugging    


### PR DESCRIPTION
Need to call PySys_SetArgvEx() to make subsequent modules that might use argv (e.g. argparse).
